### PR TITLE
Sync Configuration Fix

### DIFF
--- a/lib/features/settings/presentation/widgets/sync_filter_bottom_sheet.dart
+++ b/lib/features/settings/presentation/widgets/sync_filter_bottom_sheet.dart
@@ -359,7 +359,7 @@ class _SyncFilterBottomSheetState extends State<SyncFilterBottomSheet> {
         subtitle: Text(
           count > 0
               ? "$count ${localization.selected}"
-              : localization.all as String,
+              : localization.all,
         ),
         trailing: const Icon(Icons.arrow_forward_ios, size: 16),
         onTap: onTap,


### PR DESCRIPTION
Russian translations off-by-one until f8f8c74e3d2347b18f5d90b13f96976957384d3e. Cast {count} in "all:' translation was breaking code. Fixing translation negates need for "as String" modifier. This fixes white screen when opening Sync Configuration from Settings.