### PR TITLE
fix: resolve 401 unauthorized on shelf covers

### DIFF
--- a/lib/features/shelf_details/presentation/pages/shelf_details_page.dart
+++ b/lib/features/shelf_details/presentation/pages/shelf_details_page.dart
@@ -559,7 +559,7 @@ class ShelfDetailsPage extends StatelessWidget {
 
     return FutureBuilder<Map<String, String>>(
       future: () async {
-        final headers = apiService.getAuthHeaders(authMethod: AuthMethod.auto);
+        final headers = <String, String>{}; headers.addAll(apiService.getAuthHeaders(authMethod: AuthMethod.auto));
 
         final username = apiService.getUsername();
         final password = apiService.getPassword();


### PR DESCRIPTION
Fixes an issue where shelf covers failed to load because the auth headers map was unmodifiable. Changing it to a mutable map allows the basic auth credentials to be appended properly.