### PR TITLE
Open downloaded file when use external reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ de.doen1el.calibreWebCompanion.yml
 
 # Don't track generated localization files
 lib/l10n/app_localizations*.dart
-lib/l10n/app_localizations*.darttest/test_env.dart
+
 test/test_env.dart
 release_notes.md
 distribution/whatsnew/

--- a/android/app/src/main/kotlin/de/doen1el/calibreWebCompanion/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/doen1el/calibreWebCompanion/MainActivity.kt
@@ -1,5 +1,74 @@
 package de.doen1el.calibreWebCompanion
 
+import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "de.doen1el.calibre_web_companion/external_file_opener",
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "openContentUri" -> {
+                    val uri = call.argument<String>("uri")
+                    val mimeType = call.argument<String>("mimeType")
+
+                    if (uri.isNullOrBlank()) {
+                        result.error("invalid_arguments", "URI is required.", null)
+                        return@setMethodCallHandler
+                    }
+
+                    try {
+                        openContentUri(uri, mimeType)
+                        result.success(null)
+                    } catch (e: ActivityNotFoundException) {
+                        result.error(
+                            "activity_not_found",
+                            "No app found to open this file.",
+                            null,
+                        )
+                    } catch (e: SecurityException) {
+                        result.error(
+                            "permission_denied",
+                            e.message ?: "Permission denied while opening this file.",
+                            null,
+                        )
+                    } catch (e: Exception) {
+                        result.error(
+                            "open_failed",
+                            e.message ?: "Failed to open this file.",
+                            null,
+                        )
+                    }
+                }
+
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun openContentUri(uriString: String, mimeType: String?) {
+        val uri = Uri.parse(uriString)
+        val resolvedMimeType =
+            mimeType?.takeIf { it.isNotBlank() }
+                ?: contentResolver.getType(uri)?.takeIf { it.isNotBlank() }
+                ?: "*/*"
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, resolvedMimeType)
+            addCategory(Intent.CATEGORY_DEFAULT)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            clipData = ClipData.newUri(contentResolver, "book", uri)
+        }
+
+        startActivity(intent)
+    }
+}

--- a/lib/core/services/external_file_opener.dart
+++ b/lib/core/services/external_file_opener.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:open_file/open_file.dart';
+
+class ExternalFileOpener {
+  static const MethodChannel _channel = MethodChannel(
+    'de.doen1el.calibre_web_companion/external_file_opener',
+  );
+
+  static Future<OpenResult> open(String filePath) async {
+    if (Platform.isAndroid && filePath.startsWith('content://')) {
+      return _openAndroidContentUri(filePath);
+    }
+
+    return OpenFile.open(filePath);
+  }
+
+  static Future<OpenResult> _openAndroidContentUri(String uri) async {
+    try {
+      await _channel.invokeMethod<void>('openContentUri', {'uri': uri});
+      return OpenResult();
+    } on PlatformException catch (e) {
+      return OpenResult(
+        type: _resultTypeForPlatformException(e),
+        message: e.message ?? e.code,
+      );
+    } catch (e) {
+      return OpenResult(type: ResultType.error, message: e.toString());
+    }
+  }
+
+  static ResultType _resultTypeForPlatformException(PlatformException e) {
+    switch (e.code) {
+      case 'activity_not_found':
+        return ResultType.noAppToOpen;
+      case 'permission_denied':
+        return ResultType.permissionDenied;
+      case 'file_unavailable':
+        return ResultType.fileNotFound;
+      default:
+        return ResultType.error;
+    }
+  }
+}

--- a/lib/features/book_details/bloc/book_details_bloc.dart
+++ b/lib/features/book_details/bloc/book_details_bloc.dart
@@ -377,7 +377,9 @@ class BookDetailsBloc extends Bloc<BookDetailsEvent, BookDetailsState> {
         ),
       );
 
-      final success = await repository.openInReader(
+      final uuid = state.bookViewModel?.uuid ?? state.bookDetails!.uuid;
+
+      final openedFilePath = await repository.openInReader(
         state.bookDetails!,
         event.selectedDirectory,
         event.schema,
@@ -385,13 +387,19 @@ class BookDetailsBloc extends Bloc<BookDetailsEvent, BookDetailsState> {
           logger.d('Reader download progress: $progress%');
           emit(state.copyWith(downloadProgress: progress));
         },
+        onFileDownloaded: (path) async {
+          await downloadManager.registerDownload(uuid, path);
+          emit(state.copyWith(downloadFilePath: path, isDownloaded: true));
+        },
       );
 
-      if (success) {
+      if (openedFilePath != null) {
         emit(
           state.copyWith(
             openInReaderState: OpenInReaderState.success,
             downloadProgress: 100,
+            downloadFilePath: openedFilePath,
+            isDownloaded: true,
           ),
         );
       } else {
@@ -624,6 +632,12 @@ class BookDetailsBloc extends Bloc<BookDetailsEvent, BookDetailsState> {
           throw Exception('Downloaded file is empty');
         }
         bookBytes.addAll(bytes);
+
+        final uuid = state.bookViewModel?.uuid ?? state.bookDetails!.uuid;
+        await downloadManager.registerDownload(uuid, localFileUri);
+        emit(
+          state.copyWith(downloadFilePath: localFileUri, isDownloaded: true),
+        );
       } else {
         final response = await repository.getDownloadStream(
           event.bookId,

--- a/lib/features/book_details/data/datasources/book_details_remote_datasource.dart
+++ b/lib/features/book_details/data/datasources/book_details_remote_datasource.dart
@@ -15,6 +15,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:calibre_web_companion/core/services/api_service.dart';
+import 'package:calibre_web_companion/core/services/external_file_opener.dart';
 import 'package:calibre_web_companion/features/settings/data/models/download_schema.dart';
 import 'package:calibre_web_companion/features/book_details/data/models/book_details_model.dart';
 import 'package:calibre_web_companion/features/book_view/data/models/book_view_model.dart';
@@ -572,11 +573,12 @@ class BookDetailsRemoteDatasource {
     }
   }
 
-  Future<bool> openInReader(
+  Future<String?> openInReader(
     BookDetailsModel book,
     DocumentFile? selectedDirectory,
     DownloadSchema schema, {
     Function(int)? progressCallback,
+    Future<void> Function(String path)? onFileDownloaded,
   }) async {
     try {
       logger.i('Opening book in reader: ${book.title}');
@@ -607,29 +609,32 @@ class BookDetailsRemoteDatasource {
 
         if (file == null || !file.isFile) {
           logger.e('Downloaded file is not a valid file: $filePath');
-          return false;
+          return null;
         }
-
-        final cachedFile = await file.cache();
-        if (cachedFile == null) {
-          logger.e('Could not cache file for opening');
-          return false;
-        }
-        localPath = cachedFile.path;
+        localPath = filePath;
       }
 
-      final result = await OpenFile.open(localPath);
+      await onFileDownloaded?.call(localPath);
 
+      final result = await _openPath(localPath);
       if (result.type != ResultType.done) {
         logger.e('Error while opening the file: ${result.message}');
         throw Exception('Error while opening: ${result.message}');
       }
 
       logger.i('Opened book successfully');
-      return true;
+      return localPath;
     } catch (e) {
       logger.e('Error opening book in reader: $e');
       throw Exception('Error opening book in reader: $e');
+    }
+  }
+
+  Future<OpenResult> _openPath(String filePath) async {
+    try {
+      return await ExternalFileOpener.open(filePath);
+    } catch (e) {
+      return OpenResult(type: ResultType.error, message: e.toString());
     }
   }
 

--- a/lib/features/book_details/data/repositories/book_details_repository.dart
+++ b/lib/features/book_details/data/repositories/book_details_repository.dart
@@ -50,11 +50,12 @@ class BookDetailsRepository {
     }
   }
 
-  Future<bool> openInReader(
+  Future<String?> openInReader(
     BookDetailsModel book,
     DocumentFile? selectedDirectory,
     DownloadSchema schema, {
     Function(int)? progressCallback,
+    Future<void> Function(String path)? onFileDownloaded,
   }) async {
     try {
       return await datasource.openInReader(
@@ -62,6 +63,7 @@ class BookDetailsRepository {
         selectedDirectory,
         schema,
         progressCallback: progressCallback,
+        onFileDownloaded: onFileDownloaded,
       );
     } catch (e) {
       rethrow;


### PR DESCRIPTION
This is a supplementary fix for #146. Commit 46cbab7 add an option to download the book when press "Read Now", but the external reader will still open the cached version of the book. This brings 2 disadvantages:
1. The cached book use a temporary filename, which will be displayed in some readers.
2. Many readers store the reading progress based on the file path, so it will be different when open the downloaded version. This is inconvenient especially when the app still doesn't have a "offline mode" (looking forward to #167) and I have to open the downloaded version when offline. 

This pr fixes this problem and make the external reader open the downloaded book. I also remove a strange line from `.gitignore` btw. 

This pr was made with the help of AI, and I reviewed and tested it. 